### PR TITLE
Battlefield generation

### DIFF
--- a/generatebattlefield.py
+++ b/generatebattlefield.py
@@ -1,0 +1,90 @@
+from perlin_noise import PerlinNoise
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+import io
+
+
+# Define RGB codes for the different area types
+biomes = {
+    'CRAMPED': (102, 161, 255),
+    'HARMFUL': (255, 0, 0),
+    'ISOLATED': (255, 181, 138),
+    'OBSCURED': (229, 230, 207),
+    'PRECARIOUS': (136, 207, 112),
+    'SHELTERED': (221, 224, 162),
+    'SUFFOCATING': (54, 196, 6)
+}
+
+# Transform noise values to actual pixel values
+def GetPixelValue(danger, elevation, space):
+    if(elevation > 0.9):
+        return 'ISOLATED'
+    else:
+        if(space < 0.1):
+            return 'CRAMPED'
+        elif(space < 0.4):
+            return 'SHELTERED'
+        else:
+            if(danger < 0.1):
+                return 'OBSCURED'
+            elif(danger < 0.3):
+                return 'PRECARIOUS'
+            elif(danger < 0.6):
+                return 'SUFFOCATING'
+            else:
+                return 'HARMFUL'
+            
+def GenerateBattlefield():
+    '''Generate noise maps and combine them into RGB pixel map
+    '''
+
+    # Maybe make this configurable?
+    # Sets size of image in pixels
+    dimension = 250
+    
+    # Generate noise maps
+    # Octaves increase complexity/granularity, i.e. higher octaves make busier maps with more areas
+    dangerNoise = PerlinNoise(octaves=1)
+    elevationNoise = PerlinNoise(octaves=1)
+    spaceNoise = PerlinNoise(octaves=1)
+
+    # Convert generators to arrays
+    dangerMap = np.array([np.array([dangerNoise([i/dimension, j/dimension])+0.5 for j in range(dimension)]) for i in range(dimension)])
+    elevationMap = np.array([np.array([elevationNoise([i/dimension, j/dimension])+0.5 for j in range(dimension)]) for i in range(dimension)])
+    spaceMap = np.array([np.array([spaceNoise([i/dimension, j/dimension])+0.5 for j in range(dimension)]) for i in range(dimension)])
+
+    # Convert arrays of noise to array of pixel values in RGB space
+    myMap = np.array([np.array([biomes[GetPixelValue(dangerMap[i][j], elevationMap[i][j], spaceMap[i][j])] for j in range(dimension)]) for i in range(dimension)])
+
+    return myMap
+
+
+def GenerateImage():
+    '''Generate an RGB pixel map and convert to an IO stream for Discord'''
+    # Generate map
+    battlefieldMap = GenerateBattlefield()
+    # Convert map to Image object
+    # NOTE: .astype('uint8') is required or else the pixels get all garbled
+    mapIm = Image.fromarray(battlefieldMap.astype('uint8'), mode="RGB")
+    # Initialize final image with Discord dark mode background because I'm the only one who uses light mode
+    im = Image.new(mode='RGB', size=(250,370), color=(64, 68, 75))
+    # Place area map onto the new image
+    im.paste(mapIm, (0,0,250,250))
+    # Initialize editing
+    draw = ImageDraw.Draw(im)
+    font = ImageFont.truetype("arial.ttf", 10)
+
+    # Put a legend with colors and labels of what each area is
+    for biome in range(len(biomes)):
+        draw.rectangle((((biome%2)*100), 250+((biome//2)*30), 25+((biome%2)*100), 275+((biome//2)*30)), fill=biomes[list(biomes.keys())[biome]])
+        draw.text((((biome%2)*100)+30, 250+((biome//2)*30)), list(biomes.keys())[biome].title(), fill="white", font=font)
+    
+    # Initialize IO stream
+    data_stream = io.BytesIO()
+    # Write to IO stream
+    im.save(data_stream, format="JPEG")
+    # NOTE: MUST SEEK BACK TO 0!
+    data_stream.seek(0)
+
+    return data_stream
+

--- a/generatebattlefield.py
+++ b/generatebattlefield.py
@@ -12,12 +12,15 @@ biomes = {
     'OBSCURED': (229, 230, 207),
     'PRECARIOUS': (136, 207, 112),
     'SHELTERED': (221, 224, 162),
-    'SUFFOCATING': (54, 196, 6)
+    'SUFFOCATING': (54, 196, 6),
+    'NEUTRAL': (187, 187, 187)
 }
 
 # Transform noise values to actual pixel values
 def GetPixelValue(danger, elevation, space):
-    if(elevation > 0.9):
+    if(danger < 0.5):
+        return 'NEUTRAL'
+    elif(elevation > 0.9):
         return 'ISOLATED'
     else:
         if(space < 0.1):
@@ -25,11 +28,11 @@ def GetPixelValue(danger, elevation, space):
         elif(space < 0.4):
             return 'SHELTERED'
         else:
-            if(danger < 0.1):
+            if(danger < 0.6):
                 return 'OBSCURED'
-            elif(danger < 0.3):
+            elif(danger < 0.7):
                 return 'PRECARIOUS'
-            elif(danger < 0.6):
+            elif(danger < 0.8):
                 return 'SUFFOCATING'
             else:
                 return 'HARMFUL'

--- a/generatebattlefield.py
+++ b/generatebattlefield.py
@@ -37,19 +37,19 @@ def GetPixelValue(danger, elevation, space):
             else:
                 return 'HARMFUL'
             
-def GenerateBattlefield():
+def GenerateBattlefield(dimension=250, complexity=1):
     '''Generate noise maps and combine them into RGB pixel map
     '''
 
     # Maybe make this configurable?
     # Sets size of image in pixels
-    dimension = 250
+    #dimension = 250
     
     # Generate noise maps
     # Octaves increase complexity/granularity, i.e. higher octaves make busier maps with more areas
-    dangerNoise = PerlinNoise(octaves=1)
-    elevationNoise = PerlinNoise(octaves=1)
-    spaceNoise = PerlinNoise(octaves=1)
+    dangerNoise = PerlinNoise(octaves=complexity)
+    elevationNoise = PerlinNoise(octaves=complexity)
+    spaceNoise = PerlinNoise(octaves=complexity)
 
     # Convert generators to arrays
     dangerMap = np.array([np.array([dangerNoise([i/dimension, j/dimension])+0.5 for j in range(dimension)]) for i in range(dimension)])
@@ -62,25 +62,25 @@ def GenerateBattlefield():
     return myMap
 
 
-def GenerateImage():
+def GenerateImage(dimension=250, complexity=1):
     '''Generate an RGB pixel map and convert to an IO stream for Discord'''
     # Generate map
-    battlefieldMap = GenerateBattlefield()
+    battlefieldMap = GenerateBattlefield(dimension, complexity)
     # Convert map to Image object
     # NOTE: .astype('uint8') is required or else the pixels get all garbled
     mapIm = Image.fromarray(battlefieldMap.astype('uint8'), mode="RGB")
     # Initialize final image with Discord dark mode background because I'm the only one who uses light mode
-    im = Image.new(mode='RGB', size=(250,370), color=(64, 68, 75))
+    im = Image.new(mode='RGB', size=(dimension,370), color=(64, 68, 75))
     # Place area map onto the new image
-    im.paste(mapIm, (0,0,250,250))
+    im.paste(mapIm, (0,0,dimension,dimension))
     # Initialize editing
     draw = ImageDraw.Draw(im)
     font = ImageFont.truetype("arial.ttf", 10)
 
     # Put a legend with colors and labels of what each area is
     for biome in range(len(biomes)):
-        draw.rectangle((((biome%2)*100), 250+((biome//2)*30), 25+((biome%2)*100), 275+((biome//2)*30)), fill=biomes[list(biomes.keys())[biome]])
-        draw.text((((biome%2)*100)+30, 250+((biome//2)*30)), list(biomes.keys())[biome].title(), fill="white", font=font)
+        draw.rectangle((((biome%2)*100), dimension+((biome//2)*30), 25+((biome%2)*100), (dimension+25)+((biome//2)*30)), fill=biomes[list(biomes.keys())[biome]])
+        draw.text((((biome%2)*100)+30, dimension+((biome//2)*30)), list(biomes.keys())[biome].title(), fill="white", font=font)
     
     # Initialize IO stream
     data_stream = io.BytesIO()

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from conditions import Buttons
 from discord import app_commands
 from random_tables import RandomTables
 from battlefield import BattlefieldButtons
-from generatebattlefield import GenerateImage
+from generatebattlefield import GenerateImage, GenerateBattlefieldButtons
 
 # Define Discord intents and client
 intents = discord.Intents.default()
@@ -455,11 +455,11 @@ async def table_roll(interaction, table_name: app_commands.Choice[str]):
 @tree.command(name="generate", description="Generate a random battlefield!")
 async def generate_battlefield(interaction, complexity: int=1):
     # Get image IO stream
-    im = GenerateImage(250, complexity)
+    #im = GenerateImage(250, complexity)
     # Package into discord file object
-    chart = discord.File(im, filename="battlefield.jpg")
+    #chart = discord.File(im, filename="battlefield.jpg")
     # Send
-    await interaction.response.send_message(file=chart)
+    await interaction.response.send_message(view=GenerateBattlefieldButtons())
 
 
 

--- a/main.py
+++ b/main.py
@@ -458,7 +458,9 @@ async def generate_battlemap(interaction, dimension: int=250, complexity: int=1)
     if dimension > 1000:
         await interaction.response.send_message(content="Max dimension is 1000. Setting to 1000.", delete_after=5.0)
 
-    await interaction.response.send_message(view=GenerateBattlefieldButtons(dimension, complexity))
+    # Generate the Battlefield object and send the message
+    battlefield = GenerateBattlefieldButtons(dimension, complexity)
+    await interaction.response.send_message(view=battlefield, content=battlefield.return_string())
 
 
 @client.event

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from conditions import Buttons
 from discord import app_commands
 from random_tables import RandomTables
 from battlefield import BattlefieldButtons
-from generatebattlefield import GenerateImage, GenerateBattlefieldButtons
+from generatebattlefield import GenerateBattlefieldButtons
 
 # Define Discord intents and client
 intents = discord.Intents.default()
@@ -452,15 +452,13 @@ async def table_roll(interaction, table_name: app_commands.Choice[str]):
     await interaction.response.send_message(return_string)
 
 
-@tree.command(name="generate", description="Generate a random battlefield!")
-async def generate_battlefield(interaction, complexity: int=1):
-    # Get image IO stream
-    #im = GenerateImage(250, complexity)
-    # Package into discord file object
-    #chart = discord.File(im, filename="battlefield.jpg")
-    # Send
-    await interaction.response.send_message(view=GenerateBattlefieldButtons())
+@tree.command(name="battlemap", description="Generate a random battlefield!")
+async def generate_battlemap(interaction, dimension: int=250, complexity: int=1):
+    # Cut images that are too large down to 1000x1000
+    if dimension > 1000:
+        await interaction.response.send_message(content="Max dimension is 1000. Setting to 1000.", delete_after=5.0)
 
+    await interaction.response.send_message(view=GenerateBattlefieldButtons(dimension, complexity))
 
 
 @client.event

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from conditions import Buttons
 from discord import app_commands
 from random_tables import RandomTables
 from battlefield import BattlefieldButtons
+from generatebattlefield import GenerateImage
 
 # Define Discord intents and client
 intents = discord.Intents.default()
@@ -449,6 +450,17 @@ async def table_roll(interaction, table_name: app_commands.Choice[str]):
     # Roll on the table and return its output
     return_string = table.roll_on_table()
     await interaction.response.send_message(return_string)
+
+
+@tree.command(name="generate", description="Generate a random battlefield!")
+async def generate_battlefield(interaction):
+    # Get image IO stream
+    im = GenerateImage()
+    # Package into discord file object
+    chart = discord.File(im, filename="battlefield.jpg")
+    # Send
+    await interaction.response.send_message(file=chart)
+
 
 
 @client.event

--- a/main.py
+++ b/main.py
@@ -453,9 +453,9 @@ async def table_roll(interaction, table_name: app_commands.Choice[str]):
 
 
 @tree.command(name="generate", description="Generate a random battlefield!")
-async def generate_battlefield(interaction):
+async def generate_battlefield(interaction, complexity: int=1):
     # Get image IO stream
-    im = GenerateImage()
+    im = GenerateImage(250, complexity)
     # Package into discord file object
     chart = discord.File(im, filename="battlefield.jpg")
     # Send


### PR DESCRIPTION
Added the basics of battlefield generation. It's not integrated with your buttons, I'm not sure how you'd like to do that if at all.
The new command is `/generate`
This does require a couple of other installs:
`pip install perlin_noise pillow`

All of the sizes, colors, and definitions for what noise equates to what area are completely arbitrary. We can move those into a config file or something, maybe let the users make their own definitions based on the campaign they're running? e.g. if in a forest, add a higher chance for obscuring terrain, if in an acid swamp a higher chance for harmful, etc.